### PR TITLE
Add locale-all

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,15 @@
 
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository -y ppa:alex-p/tesseract-ocr
-RUN apt-get update && apt-get install -y tesseract-ocr-all 
+RUN apt-get update \
+    && apt-get install -y software-properties-common locales-all
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+RUN add-apt-repository -y ppa:alex-p/tesseract-ocr \
+    && apt-get update \
+    && apt-get install -y tesseract-ocr-all
 
 RUN mkdir /home/work
 WORKDIR /home/work


### PR DESCRIPTION
To get sensible output from tesseract when working with non ASCII
languages UTF-8 (or similar) is needed.

As an alternative (if you consider having locale-all too 'heavy') you might want to document the following way to extend this image to support non ASCII output:

```
FROM tesseractshadow/tesseract4re:latest

RUN apt-get update \
        && apt-get install -y locales \
        && locale-gen en_US.UTF-8

ENV LANG en_US.UTF-8
ENV LANGUAGE en_US:en
ENV LC_ALL en_US.UTF-8
```